### PR TITLE
Support Next.js

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -68,6 +68,9 @@ app.get("/readyz", async (context) => {
 app.get("/static/*", (c) => {
   return proxy(c, null, STATIC_CACHE_CONTROL);
 });
+app.get("/_next/static/*", (c) => {
+  return proxy(c, null, STATIC_CACHE_CONTROL);
+});
 
 // Get top level files under root with special handling for login and logout
 app.get("/:top", (c) => {


### PR DESCRIPTION
In #1 support for the `/_next/static` path was missed for apps built with https://nextjs.org/. This adds a route for the needed paths.