### PR TITLE
Use the Deno.serve API in place of the deno_std server

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,18 +1,6 @@
 {
   "version": "2",
   "remote": {
-    "https://deno.land/std@0.192.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
-    "https://deno.land/std@0.192.0/async/abortable.ts": "fd682fa46f3b7b16b4606a5ab52a7ce309434b76f820d3221bdfb862719a15d7",
-    "https://deno.land/std@0.192.0/async/deadline.ts": "58f72a3cc0fcb731b2cc055ba046f4b5be3349ff6bf98f2e793c3b969354aab2",
-    "https://deno.land/std@0.192.0/async/debounce.ts": "adab11d04ca38d699444ac8a9d9856b4155e8dda2afd07ce78276c01ea5a4332",
-    "https://deno.land/std@0.192.0/async/deferred.ts": "42790112f36a75a57db4a96d33974a936deb7b04d25c6084a9fa8a49f135def8",
-    "https://deno.land/std@0.192.0/async/delay.ts": "73aa04cec034c84fc748c7be49bb15cac3dd43a57174bfdb7a4aec22c248f0dd",
-    "https://deno.land/std@0.192.0/async/mod.ts": "f04344fa21738e5ad6bea37a6bfffd57c617c2d372bb9f9dcfd118a1b622e576",
-    "https://deno.land/std@0.192.0/async/mux_async_iterator.ts": "70c7f2ee4e9466161350473ad61cac0b9f115cff4c552eaa7ef9d50c4cbb4cc9",
-    "https://deno.land/std@0.192.0/async/pool.ts": "f1b8d3df4d7fd3c73f8cbc91cc2e8b8e950910f1eab94230b443944d7584c657",
-    "https://deno.land/std@0.192.0/async/retry.ts": "6521c061a5ab24e8b1ae624bdc581c4243d1d574f99dc7f5a2a195c2241fb1b8",
-    "https://deno.land/std@0.192.0/async/tee.ts": "47e42d35f622650b02234d43803d0383a89eb4387e1b83b5a40106d18ae36757",
-    "https://deno.land/std@0.192.0/http/server.ts": "1b23463b5b36e4eebc495417f6af47a6f7d52e3294827a1226d2a1aab23d9d20",
     "https://deno.land/x/hono@v3.2.7/adapter/deno/serve-static.ts": "ddbd88f85bd9b28927094de8863ef94d2ca7c3e42227b7430d8d969474cdaefa",
     "https://deno.land/x/hono@v3.2.7/client/client.ts": "7a819af2aa9aabc746add4d01715fa37f83676fdf1b63fba1bbcd655b2d066a5",
     "https://deno.land/x/hono@v3.2.7/client/index.ts": "3ff4cf246f3543f827a85a2c84d66a025ac350ee927613629bda47e854bfb7ba",

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.192.0/http/server.ts";
 import { logger } from "https://deno.land/x/hono@v3.2.7/middleware.ts";
 import { Context, Hono } from "https://deno.land/x/hono@v3.2.7/mod.ts";
 import { setResponseHeaders } from "./headers.ts";
@@ -87,4 +86,4 @@ app.get("*", (c) => {
   return proxy(c, "/index.html", INDEX_CACHE_CONTROL);
 });
 
-await serve(app.fetch, { port: PORT });
+Deno.serve({ port: PORT, handler: app.fetch });


### PR DESCRIPTION
This is being done as recommended by https://github.com/denoland/deno/issues/19690#issuecomment-1625427658. I have confirmed that it works. Note that this requires at least [`v1.35.0`](https://github.com/denoland/deno/releases/tag/v1.35.0) so that https://deno.land/api@v1.35.0?s=Deno.serve works. https://github.com/denoland/deno/pull/19141 is when the API was stabilized.